### PR TITLE
Preserve user-supplied templates in batched MMseqs2-GPU path

### DIFF
--- a/src/alphafold3/data/pipeline.py
+++ b/src/alphafold3/data/pipeline.py
@@ -1709,12 +1709,17 @@ class DataPipeline:
                                 for hit, struc in template_hits.get_hits_with_structures()
                             ]
 
+                            # Preserve any user-supplied templates from the input JSON.
+                            # When the user provided templates, run_template_search was False
+                            # above, so pdb_templates is []; we still want their templates kept.
+                            user_templates = list(chain.templates) if chain.templates else []
+
                             # Get Foldseek templates and merge
                             foldseek_tmpls = self._get_foldseek_templates(
                                 chain.sequence
                             )
                             templates = self._merge_templates(
-                                pdb_templates, foldseek_tmpls
+                                user_templates + pdb_templates, foldseek_tmpls
                             )
 
                             processed_chain = folding_input.ProteinChain(

--- a/src/alphafold3/data/pipeline.py
+++ b/src/alphafold3/data/pipeline.py
@@ -1710,8 +1710,6 @@ class DataPipeline:
                             ]
 
                             # Preserve any user-supplied templates from the input JSON.
-                            # When the user provided templates, run_template_search was False
-                            # above, so pdb_templates is []; we still want their templates kept.
                             user_templates = list(chain.templates) if chain.templates else []
 
                             # Get Foldseek templates and merge


### PR DESCRIPTION
Dear authors, this is such a useful and powerful tool for the community. I have encountered a recent issue where templates that are specified in the original af3 json are not carried over (final af3 json used before inference do not have user specified templates in them). I have tested the fixed provided in the pr on a small batch of jsons and it seems to have worked. 